### PR TITLE
Fav / RT の表示を非同期に更新する

### DIFF
--- a/timeline.rb
+++ b/timeline.rb
@@ -127,7 +127,7 @@ class Timeline
 
   def favorite
     ClientManager.instance.current.favorite(highlighted_status) do
-      @window.refresh
+      refresh_window
     end
   end
 


### PR DESCRIPTION
現状 j / k キーなどで画面を更新しないとマーカーが付かないので。