### PR TITLE
ツイートの投稿時間の表示を改善する

### DIFF
--- a/status.rb
+++ b/status.rb
@@ -6,7 +6,7 @@ class Status
   def initialize(tweet)
     @id = tweet.id
     @text = tweet.text
-    @created_at = tweet.created_at.is_a?(String) ? Time.parse(tweet.created_at) : tweet.created_at
+    @created_at = (tweet.created_at.is_a?(String) ? Time.parse(tweet.created_at) : tweet.created_at.dup).localtime
     @retweet_count = tweet.retweet_count
     @favorite_count = tweet.favorite_count
 
@@ -24,6 +24,11 @@ class Status
 
   def retweeted?
     @retweeted
+  end
+
+  def date
+    format = Time.now - @created_at < 86_400 ? '%H:%M:%S' : '%Y-%m-%d %H:%M:%S'
+    @created_at.strftime(format)
   end
 
   def favorite!

--- a/timeline.rb
+++ b/timeline.rb
@@ -56,7 +56,7 @@ class Timeline
       @window.attron(A_BOLD)
       @window.addstr(status.user.name)
       @window.attroff(A_BOLD)
-      @window.addstr(" (@#{status.user.screen_name}) [#{status.created_at}] ")
+      @window.addstr(" (@#{status.user.screen_name}) [#{status.date}] ")
 
       if status.favorited?
         @window.attron(color_pair(3))


### PR DESCRIPTION
まず、タイムゾーンの設定をきちんとする。
(今回は UTC+0900 決め打ちで、別イシューで対応してもいいかも。)

直近24時間以内の投稿であれば、時刻のみを表示する。
それ以前であれば、日付と時刻を表示する。