### PR TITLE
検索タブが落ちる

### DIFF
--- a/tab/statuses_tab.rb
+++ b/tab/statuses_tab.rb
@@ -23,7 +23,6 @@ module Tab
 
     def reply
       return if highlighted_status.nil?
-      Notifier.instance.show_message "Reply to @#{highlighted_status.user.screen_name}"
       Tweetbox.instance.compose(highlighted_status)
     end
 
@@ -196,6 +195,7 @@ module Tab
           return i
         end
       end
+      count
     end
 
     def sort


### PR DESCRIPTION
```
/Users/Ryota/dev/twterm/tab/scrollable.rb:65:in `-': Array can't be coerced into Fixnum (TypeError)
   from /Users/Ryota/dev/twterm/tab/scrollable.rb:65:in `move_down'
   from /Users/Ryota/dev/twterm/tab/scrollable.rb:21:in `respond_to_key'
   from /Users/Ryota/dev/twterm/tab/statuses_tab.rb:158:in `respond_to_key'
   from /Users/Ryota/dev/twterm/screen.rb:41:in `scan'
   from /Users/Ryota/dev/twterm/screen.rb:21:in `block (2 levels) in wait'
   from /Users/Ryota/dev/twterm/screen.rb:20:in `loop'
   from /Users/Ryota/dev/twterm/screen.rb:20:in `block in wait'
```