### PR TITLE
ふぁぼ通知などの際に HTML がエスケープされて表示されている

### DIFF
--- a/lib/twterm/notification/base.rb
+++ b/lib/twterm/notification/base.rb
@@ -4,7 +4,7 @@ module Twterm
       attr_reader :time, :fg_color, :bg_color
 
       def initialize(message)
-        @message = message
+        @message = CGI.unescapeHTML(message)
         @time = Time.now
       end
 


### PR DESCRIPTION
`&gt;` とか出てきてとてもダサかった。