### PR TITLE
Ruby の required version を書く

### DIFF
--- a/twterm.gemspec
+++ b/twterm.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |i| i == 'Gemfile.lock' }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.1.0'
 
   spec.add_dependency 'curses', '>= 1.0.1'
   spec.add_dependency 'launchy', '>= 2.4.3'


### PR DESCRIPTION
`Array#to_h` を使っているので Ruby 2.1 以上じゃないと動かない。