### PR TITLE
新規タブを開く機能のキーボードショートカットが表示されていない

### DIFF
--- a/lib/twterm/tab/statuses_tab.rb
+++ b/lib/twterm/tab/statuses_tab.rb
@@ -253,7 +253,7 @@ module Twterm
       end
 
       def show_help
-        Notifier.instance.show_help '[n] Compose  [r] Reply  [F] Favorite  [R] Retweet  [U] Show user  [w] Close tab  [Q] Quit'
+        Notifier.instance.show_help '[n] Compose  [r] Reply  [F] Favorite  [R] Retweet  [U] Show user  [N] Open new tab  [w] Close tab  [Q] Quit'
       end
     end
   end


### PR DESCRIPTION
指摘されて気付いたけど、さすがに不親切だ。