### PR TITLE
新規ツイート時にテキストが空だと落ちる

### DIFF
--- a/lib/twterm/tweetbox.rb
+++ b/lib/twterm/tweetbox.rb
@@ -91,6 +91,8 @@ module Twterm
     def post
       validate_text!
       Client.current.post(text, in_reply_to)
+    rescue EmptyTextError
+      # do nothing
     rescue InvalidCharactersError
       Notifier.instance.show_error 'Text contains invalid characters'
     rescue TextTooLongError


### PR DESCRIPTION
`EmptyTextError` を rescue していない。