### PR TITLE
screen_name や hashtag の読み込みに失敗したときに落ちる

### DIFF
--- a/lib/twterm/history/base.rb
+++ b/lib/twterm/history/base.rb
@@ -11,7 +11,11 @@ module Twterm
           return
         end
 
-        @history = YAML.load(File.read(history_file)) || []
+        begin
+          @history = YAML.load(File.read(history_file)) || []
+        rescue
+          @history = []
+        end
       end
 
       def add(hashtag)


### PR DESCRIPTION
開発時に2プロセス立ち上げていると、問題が生じることが多い。
この際なので直しておく。