### PR TITLE
Tab::UserTab や Tab::Statuses::UserTimeline が同一のものでも複数開かれるのを防ぐ

### DIFF
--- a/lib/twterm/tab/statuses/user_timeline.rb
+++ b/lib/twterm/tab/statuses/user_timeline.rb
@@ -5,10 +5,10 @@ module Twterm
         include Base
         include Dumpable
 
-        attr_reader :user
+        attr_reader :user, :user_id
 
         def ==(other)
-          other.is_a?(self.class) && user == other.user
+          other.is_a?(self.class) && user_id == other.user_id
         end
 
         def close
@@ -30,6 +30,8 @@ module Twterm
 
         def initialize(user_id)
           super()
+
+          @user_id = user_id
 
           User.find_or_fetch(user_id).then do |user|
             @user = user

--- a/lib/twterm/tab/user_tab.rb
+++ b/lib/twterm/tab/user_tab.rb
@@ -7,6 +7,10 @@ module Twterm
 
       attr_reader :user_id
 
+      def ==(other)
+        other.is_a?(self.class) && user_id == other.user_id
+      end
+
       def dump
         user_id
       end


### PR DESCRIPTION
`#==` メソッドを適切に定義してやることで、重複して開かれることを防ぐ。