### PR TITLE
特殊な文字が現れた際にも表示がズレないように、透明のスペースを表示しておく

### DIFF
--- a/lib/twterm/tab/base.rb
+++ b/lib/twterm/tab/base.rb
@@ -22,6 +22,15 @@ module Twterm
         Thread.new do
           refresh_mutex.synchronize do
             window.clear
+
+            # avoid misalignment caused by some multibyte-characters
+            window.with_color(:black, :transparent) do
+              (0...window.maxy).each do |i|
+                window.setpos(i, 0)
+                window.addch(' ')
+              end
+            end
+
             update
             window.refresh
           end if refreshable?

--- a/lib/twterm/tab/users/base.rb
+++ b/lib/twterm/tab/users/base.rb
@@ -67,15 +67,12 @@ module Twterm
           window.bold { window.addstr(title) }
 
           drawable_items.each.with_index(0) do |user, i|
-            color = scroller.current_item?(i) ? :magenta : :transparent
-
-            # also draws transparent cursors to prevent misalignment
-            window.with_color(:black, color) do
+            window.with_color(:black, :magenta) do
               window.setpos(i * 3 + 5, 3)
               window.addch(' ')
               window.setpos(i * 3 + 6, 3)
               window.addch(' ')
-            end
+            end if scroller.current_item?(i)
 
             window.setpos(i * 3 + 5, 5)
             window.bold { window.with_color(user.color) { window.addstr(user.name) } }


### PR DESCRIPTION
`Tab::Users::Base#update` で実装したように、スペースを表示しておくと、文字がズレなくなるっぽい。