### PR TITLE
タブのタイトルが変更されたときに画面を更新する

### DIFF
--- a/lib/twterm/tab/base.rb
+++ b/lib/twterm/tab/base.rb
@@ -41,6 +41,11 @@ module Twterm
         fail NotImplementedError, 'respond_to_key method must be implemented'
       end
 
+      def title=(title)
+        @title = title
+        TabManager.instance.refresh_window
+      end
+
       private
 
       def refresh_mutex

--- a/lib/twterm/tab/new/list.rb
+++ b/lib/twterm/tab/new/list.rb
@@ -19,7 +19,6 @@ module Twterm
         def initialize
           super
 
-          @title = 'New tab'
           refresh
         end
 
@@ -44,6 +43,10 @@ module Twterm
           end
 
           true
+        end
+
+        def title
+          'New tab'.freeze
         end
 
         def total_item_count

--- a/lib/twterm/tab/new/search.rb
+++ b/lib/twterm/tab/new/search.rb
@@ -20,8 +20,6 @@ module Twterm
         def initialize
           super
 
-          @title = 'New tab'
-
           update_saved_search
         end
 
@@ -76,6 +74,10 @@ module Twterm
           end
 
           true
+        end
+
+        def title
+          'New tab'.freeze
         end
 
         def total_item_count

--- a/lib/twterm/tab/new/start.rb
+++ b/lib/twterm/tab/new/start.rb
@@ -10,7 +10,6 @@ module Twterm
 
         def initialize
           super
-          @title = 'New tab'
           refresh
         end
 
@@ -30,6 +29,10 @@ module Twterm
             return false
           end
           true
+        end
+
+        def title
+          'New tab'.freeze
         end
 
         private

--- a/lib/twterm/tab/new/user.rb
+++ b/lib/twterm/tab/new/user.rb
@@ -9,12 +9,6 @@ module Twterm
           other.is_a?(self.class)
         end
 
-        def initialize
-          super
-
-          @title = 'New tab'
-        end
-
         def invoke_input
           resetter = proc do
             reset_prog_mode
@@ -57,6 +51,10 @@ module Twterm
 
         def respond_to_key(_)
           false
+        end
+
+        def title
+          'New tab'.freeze
         end
 
         private

--- a/lib/twterm/tab/statuses/conversation.rb
+++ b/lib/twterm/tab/statuses/conversation.rb
@@ -33,7 +33,6 @@ module Twterm
         end
 
         def initialize(status_id)
-          @title = 'Conversation'
           super()
 
           Status.find_or_fetch(status_id).then do |status|
@@ -44,6 +43,10 @@ module Twterm
             Thread.new { fetch_in_reply_to_status(status) }
             Thread.new { fetch_replies(status) }
           end
+        end
+
+        def title
+          'Conversation'.freeze
         end
       end
     end

--- a/lib/twterm/tab/statuses/home.rb
+++ b/lib/twterm/tab/statuses/home.rb
@@ -22,10 +22,13 @@ module Twterm
           super()
           @client = client
           @client.on_timeline_status(&method(:prepend))
-          @title = 'Home'
 
           fetch { scroller.move_to_top }
           @auto_reloader = Scheduler.new(180) { fetch }
+        end
+
+        def title
+          'Home'.freeze
         end
       end
     end

--- a/lib/twterm/tab/statuses/list_timeline.rb
+++ b/lib/twterm/tab/statuses/list_timeline.rb
@@ -10,9 +10,11 @@ module Twterm
         def initialize(list_id)
           super()
 
+          self.title = 'Loading...'.freeze
+
           List.find_or_fetch(list_id).then do |list|
             @list = list
-            @title = @list.full_name
+            self.title = @list.full_name
             TabManager.instance.refresh_window
             fetch { scroller.move_to_top }
             @auto_reloader = Scheduler.new(300) { fetch }

--- a/lib/twterm/tab/statuses/mentions.rb
+++ b/lib/twterm/tab/statuses/mentions.rb
@@ -27,10 +27,12 @@ module Twterm
             Notifier.instance.show_message "Mentioned by @#{status.user.screen_name}: #{status.text}"
           end
 
-          @title = 'Mentions'
-
           fetch { scroller.move_to_top }
           @auto_reloader = Scheduler.new(300) { fetch }
+        end
+
+        def title
+          'Mentions'.freeze
         end
       end
     end

--- a/lib/twterm/tab/user_tab.rb
+++ b/lib/twterm/tab/user_tab.rb
@@ -26,10 +26,12 @@ module Twterm
       def initialize(user_id)
         super()
 
+        self.title = 'Loading...'.freeze
         @user_id = user_id
 
         User.find_or_fetch(user_id).then do |user|
           Client.current.lookup_friendships if user.followed?.nil?
+          self.title = "@#{user.screen_name}"
         end
       end
 
@@ -183,8 +185,6 @@ module Twterm
           User.find_or_fetch(user_id).then { update }
           return
         end
-
-        @title = "@#{user.screen_name}"
 
         window.setpos(2, 3)
         window.bold { window.addstr(user.name) }


### PR DESCRIPTION
ユーザータブなどは、ユーザー ID を受け取ってから、非同期でユーザーを取得しているが、
ユーザーの取得が完了した際にタイトルを書き換えても、画面が更新されない。
`Tab::Base#title=` というメソッドを設けて、これが呼ばれた際に、 `TabManager` の画面更新処理を行うようにする。