### PR TITLE
ブラウザがない環境で Tab::Statuses::Base#open_link を実行すると落ちる

### DIFF
--- a/lib/twterm/tab/statuses/base.rb
+++ b/lib/twterm/tab/statuses/base.rb
@@ -69,6 +69,8 @@ module Twterm
           status = highlighted_status
           urls = status.urls.map(&:expanded_url) + status.media.map(&:expanded_url)
           urls.each(&Launchy.method(:open))
+        rescue Launchy::CommandNotFoundError
+          Notifier.instance.show_error 'Cannot find web browser'
         end
 
         def prepend(status)


### PR DESCRIPTION
`Launchy::CommandNotFoundError` を `rescue` してあげたい。