### PR TITLE
Modify key name from target to target_object

### DIFF
--- a/lib/twterm/streaming_client.rb
+++ b/lib/twterm/streaming_client.rb
@@ -45,7 +45,7 @@ module Twterm
 
       streaming_client.on_event(:favorite) do |event|
         user = User.new(Twitter::User.new(event[:source]))
-        status = Status.new(Twitter::Status.new(event[:target]))
+        status = Status.new(Twitter::Status.new(event[:target_object]))
 
         event = Event::Favorite.new(user, status, self)
         publish(event)


### PR DESCRIPTION
This pull request will fix an issue where tweet bodies won't be displayed in favorite notifications (#260).
It was just because of my misunderstanding about the specification of Twitter's Streaming API (target tweet of a favorite event can be accessed with `target_object` key, not `target` key.)