### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+
+rvm:
+  - 2.1
+  - 2.2
+  - 2.3.0
+
+script: bundle exec rspec


### PR DESCRIPTION
Added `.travis.yml` to run builds on Travis CI.

We'll test against Ruby 2.1 and higher, because all support for MRI 2.0 has officially ended, and we'll also drop the support for that version.