### PR TITLE
Fix definition of Enumrator::Lazy#scan

### DIFF
--- a/lib/twterm/extensions/enumerator/lazy.rb
+++ b/lib/twterm/extensions/enumerator/lazy.rb
@@ -3,7 +3,10 @@ class Enumerator
     def scan(initial, sym = nil)
       acc = initial
 
+      @_scan_has_yielded_initial_value = false
+
       Enumerator::Lazy.new(self) do |y, x|
+        y << initial && @_scan_has_yielded_initial_value = true unless @_scan_has_yielded_initial_value
         acc = sym.nil? ? yield(acc, x) : sym.to_proc.call(acc, x)
         y << acc
       end

--- a/lib/twterm/tab/direct_message/conversation.rb
+++ b/lib/twterm/tab/direct_message/conversation.rb
@@ -15,7 +15,8 @@ module Twterm
           messages.drop(scroller.offset).lazy
             .map { |m| m.text.split_by_width(window.maxx - 4).count + 2 }
             .scan(0, :+)
-            .select { |l| l < window.maxy }
+            .each_cons(2)
+            .select { |_, l| l < window.maxy }
             .count
         end
 

--- a/lib/twterm/tab/statuses/base.rb
+++ b/lib/twterm/tab/statuses/base.rb
@@ -42,7 +42,8 @@ module Twterm
           statuses.reverse.drop(scroller.offset).lazy
           .map { |s| s.split(window.maxx - 4).count + 2 }
           .scan(0, :+)
-          .select { |l| l < window.maxy }
+          .each_cons(2)
+          .select { |_, l| l < window.maxy }
           .count
         end
 

--- a/spec/twterm/extension/enumerator/lazy_spec.rb
+++ b/spec/twterm/extension/enumerator/lazy_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe Enumerator::Lazy do
+  describe '#scan' do
+    context 'when calculating summation of 0 thorugh 9' do
+      subject { [*0..9].lazy.scan(0, :+).to_a }
+
+      it { is_expected.to eq [0, 0, 1, 3, 6, 10, 15, 21, 28, 36, 45] }
+    end
+  end
+end


### PR DESCRIPTION
Fixed a bug where `Enumrator::Lazy#scan` won't yield the initial value passed as an argument.
(It's a shame I haven't been noticed such a trivial issue!)

Also fixed `#drawable_item_count` calculations depending on the method.