### PR TITLE
Fix a performance issue caused by non-blocking read

### DIFF
--- a/lib/twterm/filter_query_window.rb
+++ b/lib/twterm/filter_query_window.rb
@@ -68,7 +68,7 @@ module Twterm
         stdscr.addstr(str)
       end
 
-      Curses.timeout = 0
+      Curses.timeout = -1
       cbreak
 
       str


### PR DESCRIPTION
Fix a performance issue where non-blocking reads causes an infinite loop.
I've been misunderstood the behaviour of `Curses#timeout=`

Solved by passing a negative number so that it would use blocking read.