### PR TITLE
Fix definition of Tab::Scrollable::Scroller#nth_item_drawable?

### DIFF
--- a/lib/twterm/tab/scrollable.rb
+++ b/lib/twterm/tab/scrollable.rb
@@ -107,7 +107,7 @@ module Twterm
         end
 
         def nth_item_drawable?(n)
-          n.between?(offset, offset + drawable_item_count)
+          n.between?(offset, offset + drawable_item_count - 1)
         end
 
         def respond_to_key(key)


### PR DESCRIPTION
have been forgotten to subtract 1!

this will fix an issue where search target item sometimes does not shows up on the screen when called `find_next` or `find_previous`.