### PR TITLE
Ensure User#description returns a String

### DIFF
--- a/lib/twterm/user.rb
+++ b/lib/twterm/user.rb
@@ -61,7 +61,7 @@ module Twterm
 
       @name = user.name
       @screen_name = user.screen_name
-      @description = user.description || ''
+      @description = user.description.is_a?(Twitter::NullObject) ? '' : user.description
       @location = user.location.is_a?(Twitter::NullObject) ? '' : user.location
       @website = user.website
       @protected = user.protected?


### PR DESCRIPTION
Assign empty string instead of a `Twitter::NullObject` to `@description` inside `User` class when blank.
This will fix an issue where user tabs won't be rendered when description is empty.