### PR TITLE
Update json to v2.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     twterm (1.2.2)
       curses (~> 1.0.1)
+      json (~> 2.0.2)
       launchy (~> 2.4.3)
       oauth (~> 0.5.1)
       toml-rb (~> 0.3.14)
@@ -32,6 +33,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (1.0.1)
     http_parser.rb (0.6.0)
+    json (2.0.2)
     launchy (2.4.3)
       addressable (~> 2.3)
     memoizable (0.4.2)

--- a/twterm.gemspec
+++ b/twterm.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency 'curses', '~> 1.0.1'
+  spec.add_dependency 'json', '~> 2.0.2'
   spec.add_dependency 'launchy', '~> 2.4.3'
   spec.add_dependency 'oauth', '~> 0.5.1'
   spec.add_dependency 'toml-rb', '~> 0.3.14'


### PR DESCRIPTION
Updated [flori/json](https://github.com/flori/json) to v2.0.2 so that we can build it on Ruby 2.4, where `Fixnum` and `Bignum` is simply unified into `Integer` class.