### PR TITLE
Revert "Update json to v2.0.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     twterm (1.2.2)
       curses (~> 1.0.1)
-      json (~> 2.0.2)
       launchy (~> 2.4.3)
       oauth (~> 0.5.1)
       toml-rb (~> 0.3.14)
@@ -33,7 +32,6 @@ GEM
       domain_name (~> 0.5)
     http-form_data (1.0.1)
     http_parser.rb (0.6.0)
-    json (2.0.2)
     launchy (2.4.3)
       addressable (~> 2.3)
     memoizable (0.4.2)

--- a/twterm.gemspec
+++ b/twterm.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency 'curses', '~> 1.0.1'
-  spec.add_dependency 'json', '~> 2.0.2'
   spec.add_dependency 'launchy', '~> 2.4.3'
   spec.add_dependency 'oauth', '~> 0.5.1'
   spec.add_dependency 'toml-rb', '~> 0.3.14'


### PR DESCRIPTION
Reverting #282

I've noticed that twitter v6.0.0 no longer depends on json gem since this commit: https://github.com/sferik/twitter/commit/27980f45fb357e34b86e46cb9134d86ed29b3ce3
So this pull request seems to be unnecessary.