### PR TITLE
Fix version of twitter-text to 1.14.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       launchy (>= 2.4.3)
       oauth (>= 0.4.7)
       twitter (~> 6.0.0)
-      twitter-text (>= 1.11.0)
+      twitter-text (= 1.14.0)
 
 GEM
   remote: https://rubygems.org/

--- a/twterm.gemspec
+++ b/twterm.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'launchy', '>= 2.4.3'
   spec.add_dependency 'oauth', '>= 0.4.7'
   spec.add_dependency 'twitter', '~> 6.0.0'
-  spec.add_dependency 'twitter-text', '>= 1.11.0'
+  spec.add_dependency 'twitter-text', '1.14.0'
 
   spec.add_development_dependency 'bundler', '~> 1.8'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
twitter-text v1.14.3 includes an issue (https://github.com/twitter/twitter-text/issues/162) where a file does not exist and it cannot be run.
Resolving the problem by fixing its version.