### PR TITLE
Suppress warning caused by delegating to private method

### DIFF
--- a/lib/twterm/tab/searchable.rb
+++ b/lib/twterm/tab/searchable.rb
@@ -21,6 +21,11 @@ module Twterm
                        :searching_forward!, :searching_forward?,
                        :searching_upward!, :searching_upward?
 
+        def initialize
+          super
+          @search_query = SearchQuery.empty
+        end
+
         def find_next
           searching_forward!
 
@@ -120,10 +125,6 @@ module Twterm
             publish(hit_top) if (searching_upward? ^ searching_backward?) && index >= previous_index
             move_to(index)
           end
-        end
-
-        def search_query
-          @search_query ||= SearchQuery.empty
         end
 
         def search_query_window


### PR DESCRIPTION
On Ruby 2.4, we get warnings as `Tab::Searchable#search_query` is delegated to `Tab::Searchable::Scroller#search_query`, which is a private method.
Suppressed them by making the method public.