### PR TITLE
Return empty query when input is cancelled

### DIFF
--- a/lib/twterm/tab/searchable.rb
+++ b/lib/twterm/tab/searchable.rb
@@ -84,7 +84,7 @@ module Twterm
         private
 
         def ask
-          @search_query = search_query_window.input
+          @search_query = search_query_window.input || SearchQuery.empty
         end
 
         def search


### PR DESCRIPTION
Fixed a bug where search query input mode cannot be cancelled with ^C or backspace.