### PR TITLE
Complete missing comma

### DIFF
--- a/lib/twterm/tab/dumpable.rb
+++ b/lib/twterm/tab/dumpable.rb
@@ -2,7 +2,7 @@ module Twterm
   module Tab
     module Dumpable
       def dump
-        fail NotImplementedError 'dump method must be implemented'
+        fail NotImplementedError, 'dump method must be implemented'
       end
 
       def self.included(klass)


### PR DESCRIPTION
Completed missing comma. This seems to have been causing `NoMethodError`.