### PR TITLE
Handle key mapper errors more carefully

### DIFF
--- a/lib/twterm/key_mapper.rb
+++ b/lib/twterm/key_mapper.rb
@@ -1,6 +1,9 @@
 require 'toml'
 require 'singleton'
 
+require 'twterm/key_mapper/no_such_command'
+require 'twterm/key_mapper/no_such_key'
+
 require_relative './app'
 require_relative './key_mapper/abstract_key_mapper'
 require_relative './key_mapper/app_key_mapper'
@@ -58,18 +61,14 @@ module Twterm
       @mappings = MAPPERS
         .map { |c, m| { c => m.new(dict[c]) } }
         .reduce({}) { |acc, x| acc.merge(x) }
-    rescue AbstractKeyMapper::NoSuchCommand => e
-      command = e.message
-
-      warn "Unrecognized command detected: #{command}"
+    rescue NoSuchCommand => e
+      warn "Unrecognized command detected: #{e.full_command}"
       warn 'Make sure you have specified the correct command'
       warn "Your key assignments are defined in #{dict_file_path}"
 
       exit
-    rescue AbstractKeyMapper::NoSuchKey => e
-      key = e.message
-
-      warn "Unrecognized key detected: #{key}"
+    rescue NoSuchKey => e
+      warn "Unrecognized key detected: #{e.key}"
       warn 'Make sure you have specified the correct key'
       warn "Your key assignments are defined in #{dict_file_path}"
 

--- a/lib/twterm/key_mapper.rb
+++ b/lib/twterm/key_mapper.rb
@@ -101,20 +101,28 @@ module Twterm
 
     def load_dict_file!
       dict = TOML.load_file(dict_file_path, symbolize_keys: true)
-    rescue TOML::ParseError
-      warn "Your key assignments dictionary file (#{dict_file_path}) could not be parsed"
-      warn 'Falling back to the default key assignments'
-      warn ''
-      warn 'Check the syntax and edit the file manually,'
-      warn 'or remove it and launch twterm again to restore'
-      warn ''
-      warn 'Press any key to continue'
+    rescue TOML::ParseError, TOML::ValueOverwriteError => e
+      first_line =
+        case e
+        when TOML::ParseError
+          "Your key assignments dictionary file (#{dict_file_path}) could not be parsed"
+        when TOML::ValueOverwriteError
+          "Command `#{e.key}` is declared more than once"
+        end
+
+      warn <<-EOS
+#{first_line}
+Falling back to the default key assignments
+
+Check the syntax and edit the file manually,
+or remove it and launch twterm again to restore
+
+Press any key to continue
+      EOS
 
       getc
-
-      dict = default_mappings
     ensure
-      assign_mappings!(dict)
+      assign_mappings!(dict || default_mappings)
     end
   end
 end

--- a/lib/twterm/key_mapper/abstract_key_mapper.rb
+++ b/lib/twterm/key_mapper/abstract_key_mapper.rb
@@ -1,16 +1,15 @@
 require 'curses'
+require 'twterm/key_mapper/no_such_command'
+require 'twterm/key_mapper/no_such_key'
 
 module Twterm
   class KeyMapper
     class AbstractKeyMapper
-      class NoSuchCommand < StandardError; end
-      class NoSuchKey < StandardError; end
-
       def initialize(mappings)
         commands = self.class.commands
 
         mappings.keys.each do |k|
-          raise NoSuchCommand, "#{self.class.category}.#{k}" unless commands.include?(k)
+          raise NoSuchCommand.new(self.class.category, k) unless commands.include?(k)
         end
 
         @mappings = Hash[mappings.map { |k, v| [k, translate(v)] }]
@@ -39,7 +38,7 @@ module Twterm
         when 'F11' then Curses::Key::F11
         when 'F12' then Curses::Key::F12
         else
-          raise NoSuchKey, key
+          raise NoSuchKey.new(key)
         end
       end
 

--- a/lib/twterm/key_mapper/abstract_key_mapper.rb
+++ b/lib/twterm/key_mapper/abstract_key_mapper.rb
@@ -16,6 +16,7 @@ module Twterm
       end
 
       def [](key)
+        raise NoSuchCommand.new(self.class.category, key) unless @mappings.keys.include?(key)
         @mappings[key]
       end
 

--- a/lib/twterm/key_mapper/no_such_command.rb
+++ b/lib/twterm/key_mapper/no_such_command.rb
@@ -1,0 +1,20 @@
+module Twterm
+  class KeyMapper
+    class NoSuchCommand < StandardError
+      attr_reader :category, :command
+
+      def initialize(category, command)
+        @category, @command = category, command
+        super(message)
+      end
+
+      def full_command
+        "#{category}.#{command}"
+      end
+
+      def message
+        "No such command: #{full_command}"
+      end
+    end
+  end
+end

--- a/lib/twterm/key_mapper/no_such_key.rb
+++ b/lib/twterm/key_mapper/no_such_key.rb
@@ -1,0 +1,16 @@
+module Twterm
+  class KeyMapper
+    class NoSuchKey < StandardError
+      attr_reader :key
+
+      def initialize(key)
+        @key = key
+        super(message)
+      end
+
+      def message
+        "No such key: #{key}"
+      end
+    end
+  end
+end

--- a/lib/twterm/tab/direct_message/conversation.rb
+++ b/lib/twterm/tab/direct_message/conversation.rb
@@ -64,8 +64,6 @@ module Twterm
           k = KeyMapper.instance
 
           case key
-          when k[:tab, :filter]
-            filter
           when k[:status, :compose], k[:status, :reply]
             DirectMessageComposer.instance.compose(conversation.collocutor)
           else

--- a/lib/twterm/tab/direct_message/conversation_list.rb
+++ b/lib/twterm/tab/direct_message/conversation_list.rb
@@ -62,8 +62,6 @@ module Twterm
           when k[:status, :compose], k[:status, :reply]
             conversation = current_item
             DirectMessageComposer.instance.compose(conversation.collocutor)
-          when k[:tab, :filter]
-            filter
           else
             return false
           end


### PR DESCRIPTION
This pull request makes the app handle key mapper errors more carefully, introducing more object-oriented `KeyMapper::NoSuchCommand` and `KeyMapper::NoSuchKey` error classes.
`TOML::ValueOverwriteError` will be also rescued even if the key configurations file is ill-formatted.