### PR TITLE
Rescue Errno::ETIMEDOUT

### DIFF
--- a/lib/twterm/streaming_client.rb
+++ b/lib/twterm/streaming_client.rb
@@ -54,7 +54,7 @@ module Twterm
           publish(Event::Notification::Error.new('Rate limit exceeded'))
           sleep 120
           retry
-        rescue Errno::ENETUNREACH, Resolv::ResolvError
+        rescue Errno::ENETUNREACH, Errno::ETIMEDOUT, Resolv::ResolvError
           publish(Event::Notification::Error.new('Network is unavailable'))
           sleep 30
           retry


### PR DESCRIPTION
Rescues `Errno::ETIMEDOUT` which can be raised within establishing a new connection for the user streams.