### PR TITLE
Pay more attention to thread safety

### DIFF
--- a/lib/twterm/repository/abstract_entity_repository.rb
+++ b/lib/twterm/repository/abstract_entity_repository.rb
@@ -1,3 +1,5 @@
+require 'concurrent'
+
 require 'twterm/repository/abstract_repository'
 
 module Twterm
@@ -24,7 +26,7 @@ module Twterm
       private
 
       def empty_repository
-        {}
+        Concurrent::Hash.new
       end
 
       def extract_key(args)

--- a/lib/twterm/repository/abstract_expirable_entity_repository.rb
+++ b/lib/twterm/repository/abstract_expirable_entity_repository.rb
@@ -1,3 +1,5 @@
+require 'concurrent'
+
 require 'twterm/repository/abstract_entity_repository'
 
 module Twterm
@@ -5,7 +7,7 @@ module Twterm
     class AbstractExpirableEntityRepository < AbstractEntityRepository
       def initialize
         super
-        @touched_at = {}
+        @touched_at = Concurrent::Hash.new
       end
 
       def create(args)

--- a/lib/twterm/repository/friendship_repository.rb
+++ b/lib/twterm/repository/friendship_repository.rb
@@ -1,3 +1,5 @@
+require 'concurrent'
+
 require 'twterm/friendship'
 require 'twterm/repository//abstract_repository'
 
@@ -10,10 +12,11 @@ module Twterm
         super
 
         @user_ids = Set.new
+        @m = Mutex.new
       end
 
       def already_looked_up?(user_id)
-        @user_ids.include?(user_id)
+        @m.synchronize { @user_ids.include?(user_id) }
       end
 
       def block(from, to)
@@ -53,7 +56,7 @@ module Twterm
       end
 
       def looked_up!(user_id)
-        @user_ids << user_id
+        @m.synchronize { @user_ids << user_id }
         user_id
       end
 
@@ -90,7 +93,7 @@ module Twterm
       end
 
       def empty_repository
-        Friendship::STATUSES.map { |s| [s, []] }.to_h
+        Friendship::STATUSES.map { |s| [s, Concurrent::Array.new] }.to_h
       end
 
       def store(instance)

--- a/lib/twterm/tab/new/search.rb
+++ b/lib/twterm/tab/new/search.rb
@@ -1,3 +1,5 @@
+require 'concurrent'
+
 require 'twterm/tab/base'
 require 'twterm/tab/loadable'
 
@@ -9,7 +11,7 @@ module Twterm
         include Readline
         include Searchable
 
-        @@queries = []
+        @@queries = Concurrent::Array.new
 
         def ==(other)
           other.is_a?(self.class)

--- a/lib/twterm/tab/statuses/base.rb
+++ b/lib/twterm/tab/statuses/base.rb
@@ -1,3 +1,5 @@
+require 'concurrent'
+
 require 'twterm/event/open_uri'
 require 'twterm/event/status/delete'
 require 'twterm/publisher'
@@ -62,7 +64,7 @@ module Twterm
         def initialize
           super
 
-          @status_ids = []
+          @status_ids = Concurrent::Array.new
 
           subscribe(Event::Status::Delete) { |e| delete(e.status_id) }
         end

--- a/lib/twterm/tab/users/base.rb
+++ b/lib/twterm/tab/users/base.rb
@@ -1,3 +1,5 @@
+require 'concurrent'
+
 require 'twterm/tab/base'
 require 'twterm/tab/loadable'
 
@@ -18,7 +20,7 @@ module Twterm
 
         def initialize
           super()
-          @user_ids = []
+          @user_ids = Concurrent::Array.new
         end
 
         def items


### PR DESCRIPTION
Replaced mutable data structures such as `Array` or `Hash` which can be referenced from multiple threads with thread-safe ones (e.g. `Concurrent::Array`, `Concurrent::Hash`, provided by concurrent-ruby), in order to avoid data races.