### PR TITLE
Prepare for v2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    twterm (1.2.2)
+    twterm (2.0.0.beta1)
       concurrent-ruby (~> 1.0.5)
       curses (~> 1.2.2)
       launchy (~> 2.4.3)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # twterm
 
-A full-featured CLI Twitter client
+A full-featured TUI Twitter client
 
 ## Screenshot
 

--- a/README.md
+++ b/README.md
@@ -26,25 +26,21 @@ To launch twterm, just type in your console:
 $ twterm
 ```
 
-### Basic key assignments
+### Default key assignments
+
+Key assignments can be configured by editing `~/.twterm/keys.toml`
 
 key | operation
 --- | ---
-`F` | add to favorite
-`d` `C-d` | scroll down
-`h` `C-b` `←` | show previous tab
-`j` `C-n` `↓` | move down
-`k` `C-p` `↑` | move up
-`l` `C-f` `→` | show next tab
-`n` | compose new tweet
-`N` | open new tab
-`r` | reply
-`R` | retweet
+`h` `←` | previous tab
+`j` `↓` | move down
+`k` `↑` | move up
+`l` `→` | next tab
+`^N` | new tweet
+`^T` | new tab
 `w` | close current tab
-`Q` | quit
-`?` | open key assignments cheatsheet
-
-Type `?` key to see the full list of key assignments.
+`F10` | quit
+`F1` | key assignments cheatsheet
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A full-featured TUI Twitter client
 
 ## Requirements
 
-- Ruby (>= 2.1, compiled with C Curses and Readline)
-- C curses
+- Ruby (>= 2.1, compiled with ncurses and Readline)
+- ncurses
 - Readline
 
 ## Installation

--- a/lib/twterm/version.rb
+++ b/lib/twterm/version.rb
@@ -1,3 +1,3 @@
 module Twterm
-  VERSION = '1.2.2'
+  VERSION = '2.0.0.beta1'
 end

--- a/twterm.gemspec
+++ b/twterm.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |i| i == 'Gemfile.lock' }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.1.0'
 
   spec.add_dependency 'curses', '~> 1.2.2'
   spec.add_dependency 'concurrent-ruby', '~> 1.0.5'

--- a/twterm.gemspec
+++ b/twterm.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Ryota Kameoka']
   spec.email         = ['kameoka.ryota@gmail.com']
 
-  spec.summary       = 'A full-featured CLI Twitter client'
-  spec.description   = 'A full-featured CLI Twitter client'
+  spec.summary       = 'A full-featured TUI Twitter client'
+  spec.description   = 'A full-featured TUI Twitter client'
   spec.homepage      = 'http://twterm.ryota-ka.me/'
   spec.license       = 'MIT'
 


### PR DESCRIPTION
Updated readme, description, required Ruby version, and bumped version to v2.0.0.beta1.