### PR TITLE
Change default key assignment for status.like to F

### DIFF
--- a/lib/twterm/key_mapper/status_key_mapper.rb
+++ b/lib/twterm/key_mapper/status_key_mapper.rb
@@ -5,7 +5,7 @@ class Twterm::KeyMapper::StatusKeyMapper < Twterm::KeyMapper::AbstractKeyMapper
     compose: '^N',
     conversation: 'c',
     destroy: 'D',
-    like: 'L',
+    like: 'F',
     open_link: 'o',
     reply: 'r',
     retweet: 'R',


### PR DESCRIPTION
Changed default key assignment for `status.like` from `L` to `F`, as it has been overlapped with `cursor.move_to_bottom`.