### PR TITLE
Bump version to v2.0.0.beta2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    twterm (2.0.0.beta1)
+    twterm (2.0.0.beta2)
       concurrent-ruby (~> 1.0.5)
       curses (~> 1.2.2)
       launchy (~> 2.4.3)

--- a/lib/twterm/version.rb
+++ b/lib/twterm/version.rb
@@ -1,3 +1,3 @@
 module Twterm
-  VERSION = '2.0.0.beta1'
+  VERSION = '2.0.0.beta2'
 end


### PR DESCRIPTION
Bumped version to v2.0.0.beta, including colored badges in user tabs and changed default key assignment.