### PR TITLE
Clarify responsibilities between #fetch and #reload

### DIFF
--- a/lib/twterm/tab/base.rb
+++ b/lib/twterm/tab/base.rb
@@ -107,6 +107,13 @@ module Twterm
         )
       end
 
+      def reload
+        fetch.then do |statuses|
+          statuses.each { |s| append(s) }
+          sort
+        end
+      end
+
       def resize(event)
         window.resize(stdscr.maxy - 5, stdscr.maxx)
         window.move(3, 0)

--- a/lib/twterm/tab/statuses/base.rb
+++ b/lib/twterm/tab/statuses/base.rb
@@ -138,7 +138,7 @@ module Twterm
           when k[:status, :retweet]
             retweet
           when k[:tab, :reload]
-            fetch
+            reload
           when k[:status, :user]
             show_user
           else

--- a/lib/twterm/tab/statuses/favorites.rb
+++ b/lib/twterm/tab/statuses/favorites.rb
@@ -17,10 +17,7 @@ module Twterm
         end
 
         def fetch
-          client.favorites(@user.id).then do |statuses|
-            statuses.each { |s| append(s) }
-            sort
-          end
+          client.favorites(@user.id)
         end
 
         def initialize(app, client, user_id)
@@ -32,7 +29,7 @@ module Twterm
             @user = user
             app.tab_manager.refresh_window
 
-            fetch.then do
+            reload.then do
               initially_loaded!
               scroller.move_to_top
             end

--- a/lib/twterm/tab/statuses/home.rb
+++ b/lib/twterm/tab/statuses/home.rb
@@ -15,10 +15,7 @@ module Twterm
         end
 
         def fetch
-          client.home_timeline.then do |statuses|
-            statuses.each { |s| append(s) }
-            sort
-          end
+          client.home_timeline
         end
 
         def initialize(app, client)
@@ -26,12 +23,12 @@ module Twterm
 
           subscribe(Event::Status::Timeline) { |e| prepend(e.status) }
 
-          fetch.then do
+          reload.then do
             initially_loaded!
             scroller.move_to_top
           end
 
-          @auto_reloader = Scheduler.new(180) { fetch }
+          @auto_reloader = Scheduler.new(180) { reload }
         end
 
         def title

--- a/lib/twterm/tab/statuses/list_timeline.rb
+++ b/lib/twterm/tab/statuses/list_timeline.rb
@@ -18,20 +18,17 @@ module Twterm
             self.title = @list.full_name
             app.tab_manager.refresh_window
 
-            fetch.then do
+            reload.then do
               initially_loaded!
               scroller.move_to_top
             end
 
-            @auto_reloader = Scheduler.new(300) { fetch }
+            @auto_reloader = Scheduler.new(300) { reload }
           end
         end
 
         def fetch
-          client.list_timeline(@list).then do |statuses|
-            statuses.each { |s| append(s) }
-            sort
-          end
+          client.list_timeline(@list)
         end
 
         def close

--- a/lib/twterm/tab/statuses/mentions.rb
+++ b/lib/twterm/tab/statuses/mentions.rb
@@ -21,20 +21,13 @@ module Twterm
 
           subscribe(Event::Status::Mention) { |e| prepend(e.status) }
 
-          fetch.then do |statuses|
+          reload.then do |statuses|
             initially_loaded!
             statuses.each { |s| append(s) }
             scroller.move_to_top
           end
 
           @auto_reloader = Scheduler.new(300) { reload }
-        end
-
-        def reload
-          fetch.then do |statuses|
-            statuses.each { |s| append(s) }
-            sort
-          end
         end
 
         def title

--- a/lib/twterm/tab/statuses/search.rb
+++ b/lib/twterm/tab/statuses/search.rb
@@ -22,10 +22,7 @@ module Twterm
         end
 
         def fetch
-          client.search(@query).then do |statuses|
-            statuses.each(&method(:append))
-            sort
-          end
+          client.search(@query)
         end
 
         def initialize(app, client, query)
@@ -34,12 +31,12 @@ module Twterm
           @query = query
           @title = "\"#{@query}\""
 
-          fetch.then do
+          reload.then do
             initially_loaded!
             scroller.move_to_top
           end
 
-          @auto_reloader = Scheduler.new(300) { fetch }
+          @auto_reloader = Scheduler.new(300) { reload }
         end
       end
     end

--- a/lib/twterm/tab/statuses/user_timeline.rb
+++ b/lib/twterm/tab/statuses/user_timeline.rb
@@ -22,10 +22,7 @@ module Twterm
         end
 
         def fetch
-          client.user_timeline(@user.id).then do |statuses|
-            statuses.each { |s| append(s) }
-            sort
-          end
+          client.user_timeline(@user.id)
         end
 
         def initialize(app, client, user_id)
@@ -37,12 +34,12 @@ module Twterm
             @user = user
             app.tab_manager.refresh_window
 
-            fetch.then do
+            reload.then do
               initially_loaded!
               scroller.move_to_top
             end
 
-            @auto_reloader = Scheduler.new(120) { fetch }
+            @auto_reloader = Scheduler.new(120) { reload }
           end
         end
 


### PR DESCRIPTION
Clarified responsibilities between `#fetch` and `#reload` methods on status tab classes, which has been quite vague.

- `#fetch` method 
  - now focusing on obtain statuses from the server
  - does nothing except above
  - returns a promise of fetched statuses
- `#reload` method
  - obtains statuses via `#fetch`
  - sorts statuses in the tab
  - re-renders the screen
  - now can be commonly defined in the superclass (`Tab::Statuses::Base`)

And `tab.reload` now invokes `#reload` method.