### PR TITLE
Modify identity determination of Tab::Statuses::ListTimeline

### DIFF
--- a/lib/twterm/rest_client.rb
+++ b/lib/twterm/rest_client.rb
@@ -161,11 +161,9 @@ module Twterm
       end
     end
 
-    def list_timeline(list)
-      fail ArgumentError,
-        'argument must be an instance of List class' unless list.is_a? List
+    def list_timeline(list_id)
       send_request do
-        rest_client.list_timeline(list.id, count: 200)
+        rest_client.list_timeline(list_id, count: 200)
       end.then do |statuses|
         statuses
         .select(&@mute_filter)

--- a/lib/twterm/tab/statuses/list_timeline.rb
+++ b/lib/twterm/tab/statuses/list_timeline.rb
@@ -6,16 +6,17 @@ module Twterm
       class ListTimeline < Base
         include Dumpable
 
-        attr_reader :list
+        attr_reader :list_id
 
         def initialize(app, client, list_id)
           super(app, client)
 
+          @list_id = list_id
+
           self.title = 'Loading...'.freeze
 
           find_or_fetch_list(list_id).then do |list|
-            @list = list
-            self.title = @list.full_name
+            self.title = list.full_name
             app.tab_manager.refresh_window
 
             reload.then do
@@ -28,7 +29,7 @@ module Twterm
         end
 
         def fetch
-          client.list_timeline(@list)
+          client.list_timeline(list_id)
         end
 
         def close
@@ -37,11 +38,11 @@ module Twterm
         end
 
         def ==(other)
-          other.is_a?(self.class) && list == other.list
+          other.is_a?(self.class) && list_id == other.list_id
         end
 
         def dump
-          @list.id
+          list_id
         end
       end
     end


### PR DESCRIPTION
Modified the definition of `Tab::Statuses::ListTimeline#==` to compare their list ids, instead of lists themselves. This should fix the problem where the list tabs won't be restored correctly.