### PR TITLE
Update design for checkbox image

### DIFF
--- a/lib/twterm/image.rb
+++ b/lib/twterm/image.rb
@@ -45,7 +45,7 @@ class Twterm::Image
   end
 
   def self.checkbox(checked)
-    string(checked ? 'x' : ' ').brackets
+    string(checked ? '*' : ' ').brackets
   end
 
   def color(fg, bg = :transparent)


### PR DESCRIPTION
Use `*` instead of `x` to render checkmarks.