### PR TITLE
Define #reload in proper class

### DIFF
--- a/lib/twterm/tab/base.rb
+++ b/lib/twterm/tab/base.rb
@@ -107,13 +107,6 @@ module Twterm
         )
       end
 
-      def reload
-        fetch.then do |statuses|
-          statuses.each { |s| append(s) }
-          sort
-        end
-      end
-
       def resize(event)
         window.resize(stdscr.maxy - 5, stdscr.maxx)
         window.move(3, 0)

--- a/lib/twterm/tab/statuses/base.rb
+++ b/lib/twterm/tab/statuses/base.rb
@@ -235,6 +235,13 @@ module Twterm
             .reduce(Image.empty, :|)
         end
 
+        def reload
+          fetch.then do |statuses|
+            statuses.each { |s| append(s) }
+            sort
+          end
+        end
+
         def sort
           return if items.empty? || scroller.current_item.nil?
 


### PR DESCRIPTION
Defined `#reload` method in `Tab::Statuses::Base`, not in `Tab::Base`.