### PR TITLE
Modify definition of Tab::Statuses::Conversation#==

### DIFF
--- a/lib/twterm/tab/statuses/conversation.rb
+++ b/lib/twterm/tab/statuses/conversation.rb
@@ -11,7 +11,7 @@ module Twterm
         attr_reader :status_id
 
         def ==(other)
-          other.is_a?(self.class) && status == other.status
+          other.is_a?(self.class) && status_id == other.status_id
         end
 
         def fetch


### PR DESCRIPTION
Fixed `NameError` caused by referencing `status`.
This should fix the problem where multiple conversation tab cannot be opened at the same time.
(@morishin thank you for telling me about the problem :wink:)