### PR TITLE
Complete missing commands

### DIFF
--- a/lib/twterm/key_mapper.rb
+++ b/lib/twterm/key_mapper.rb
@@ -74,9 +74,15 @@ module Twterm
       exit
     end
 
+    def complete_missing_commands!(dict)
+      completed_dict = default_mappings.merge(dict.map { |k, v| [k, v.to_h] }.to_h) { |_, l, r| l.merge(r.to_h) }
+
+      assign_mappings!(completed_dict)
+      save!(completed_dict)
+    end
+
     def create_default_dict_file!
-      dict = TOML.dump(default_mappings).gsub("\n[", "\n\n[")
-      File.open(dict_file_path, 'w', 0644) { |f| f.write(dict) }
+      save!(default_mappings)
     end
 
     def default_mappings
@@ -122,6 +128,12 @@ Press any key to continue
       getc
     ensure
       assign_mappings!(dict || default_mappings)
+      complete_missing_commands!(dict) unless dict.nil?
+    end
+
+    def save!(mappings)
+      dict = TOML.dump(mappings).gsub("\n[", "\n\n[")
+      File.open(dict_file_path, 'w', 0644) { |f| f.write(dict) }
     end
   end
 end

--- a/lib/twterm/key_mapper/abstract_key_mapper.rb
+++ b/lib/twterm/key_mapper/abstract_key_mapper.rb
@@ -5,19 +5,26 @@ require 'twterm/key_mapper/no_such_key'
 module Twterm
   class KeyMapper
     class AbstractKeyMapper
-      def initialize(mappings)
+      def initialize(dict)
         commands = self.class.commands
 
-        mappings.keys.each do |k|
+        dict ||= {}
+
+        dict.keys.each do |k|
           raise NoSuchCommand.new(self.class.category, k) unless commands.include?(k)
         end
 
-        @mappings = Hash[mappings.map { |k, v| [k, translate(v)] }]
+        @mappings = Hash[dict.map { |k, v| [k, translate(v)] }]
+        @dict = dict
       end
 
       def [](key)
         raise NoSuchCommand.new(self.class.category, key) unless @mappings.keys.include?(key)
         @mappings[key]
+      end
+
+      def to_h
+        @dict
       end
 
       private


### PR DESCRIPTION
Automatically add missing commands to `~/.twterm/keys.toml` when launched. This enables us to safely add a new command in the future.