### PR TITLE
Set Thread.report_on_exception = false

### DIFF
--- a/bin/twterm
+++ b/bin/twterm
@@ -1,5 +1,9 @@
 #!/usr/bin/env ruby
 
+if RUBY_VERSION >= '2.5.0'
+  Thread.report_on_exception = false
+end
+
 if ARGV.count == 1 && (%w(-v --version).include?(ARGV.first))
   require 'twterm/version'
   puts 'twterm version %s' % Twterm::VERSION


### PR DESCRIPTION
It's an awful idea to make it default to report exceptions on stderr, especially for such a multi-threaded full-screen app...