### PR TITLE
Word Wrap

### DIFF
--- a/lib/twterm/extensions/string.rb
+++ b/lib/twterm/extensions/string.rb
@@ -1,3 +1,17 @@
+require 'word_wrap'
+require 'word_wrap/core_ext'
+
+class String
+  def width
+    each_char.map { |c| c.bytesize == 1 ? 1 : 2 }.reduce(0, &:+)
+  end
+
+  def split_by_width(width)
+    (self.fit width).split "\n"
+  end
+end
+
+=begin
 class String
   def width
     each_char.map { |c| c.bytesize == 1 ? 1 : 2 }.reduce(0, &:+)
@@ -28,3 +42,4 @@ class String
     chunks
   end
 end
+=end

--- a/lib/twterm/photo_viewer_backend/imgcat_backend.rb
+++ b/lib/twterm/photo_viewer_backend/imgcat_backend.rb
@@ -17,7 +17,7 @@ module Twterm
         with_downloaded_file(url) do |file|
           begin
             puts "\e[H\e[2JRendering..."
-            system "imgcat #{file.path}"
+            system "imgcat --half-height #{file.path}"
             getc
           ensure
             puts "\e[H\e[2J"

--- a/lib/twterm/tab/abstract_tab.rb
+++ b/lib/twterm/tab/abstract_tab.rb
@@ -54,7 +54,7 @@ module Twterm
       def initialize(app, client)
         @app, @client = app, client
 
-        @window = stdscr.subwin(stdscr.maxy - 5, stdscr.maxx, 3, 0)
+        @window = stdscr.subwin(stdscr.maxy - 5, stdscr.maxx-1, 3, 0)
 
         subscribe(Event::Screen::Resize, :resize)
       end

--- a/lib/twterm/tab/status_tab.rb
+++ b/lib/twterm/tab/status_tab.rb
@@ -25,7 +25,7 @@ module Twterm
       end
 
       def drawable_item_count
-        (window.maxy - status.text.split_by_width(window.maxx - 4).count - 6).div(2)
+        (window.maxy - status.text.split_by_width(window.maxx - 5).count - 6).div(2)
       end
 
       def dump
@@ -55,7 +55,7 @@ module Twterm
         [
           header,
           Image.blank_line,
-          *status.text.split_by_width(window.maxx - 4).map { |x| Image.string(x) },
+          *status.text.split_by_width(window.maxx - 5).map { |x| Image.string(x) },
           Image.blank_line,
           Image.blank_line,
           *drawable_items.flat_map.with_index do |item, i|

--- a/lib/twterm/tab/user_tab.rb
+++ b/lib/twterm/tab/user_tab.rb
@@ -277,7 +277,7 @@ module Twterm
               .reduce(Image.empty, :-)
           end
 
-        description = user.description.split_by_width(window.maxx - 4)
+        description = user.description.split_by_width(window.maxx - 5)
           .map(&Image.method(:string))
           .reduce(Image.empty, :|)
 

--- a/twterm.gemspec
+++ b/twterm.gemspec
@@ -26,8 +26,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'toml-rb', '~> 0.3.14'
   spec.add_dependency 'twitter', '~> 6.2.0'
   spec.add_dependency 'twitter-text', '~> 2.1.0'
+  spec.add_dependency 'word_wrap', '~> 1.0.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.8'
+  spec.add_development_dependency 'bundler', '~> 2.0.1'
   spec.add_development_dependency 'hashie', '~> 3.5.6'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.7.0'


### PR DESCRIPTION
I have tried to implement word wrapping. I am not very proficient in Ruby.

This is a work in progress. Unfinished, unpolished, but usable. The tweets do indeed wrap more nicely than the default abrupt cuts.

I'm posting this here to the benefit of the people from issue #346 or whoever might like to try it and help improve it.

### TODO

- [ ] I think the modifications on the `maxx` calculations are wrong: I want to add a 1 line gutter to the right but I haven't figured out how yet.
- [ ] I think the `maxy` calculations might also be off but I'm not sure. The last one or two tweets do escape the bottom of the page sometimes.
- [ ] The tab bar at the top also needs to be wrapped nicely.