### PR TITLE
Drop support for Ruby <2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,24 +19,6 @@ aliases:
           bundle exec rspec
 
 jobs:
-  build-2.1:
-    docker:
-      - image: ruby:2.1
-    steps:
-      *build-steps
-
-  build-2.2:
-    docker:
-      - image: ruby:2.2
-    steps:
-      *build-steps
-
-  build-2.3:
-    docker:
-      - image: ruby:2.3
-    steps:
-      *build-steps
-
   build-2.4:
     docker:
       - image: ruby:2.4
@@ -60,9 +42,6 @@ workflows:
 
   build:
     jobs:
-      - build-2.1
-      - build-2.2
-      - build-2.3
       - build-2.4
       - build-2.5
       - build-2.6

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A full-featured TUI Twitter client
 
 ## Requirements
 
-- Ruby (>= 2.1, compiled with ncurses and Readline)
+- Ruby (>= 2.4, compiled with ncurses and Readline)
 - ncurses
 - Readline
 - [GNU Libidn](https://www.gnu.org/software/libidn/)


### PR DESCRIPTION
Dropped support for Ruby <2.4, which have reached their EoL.