### PR TITLE
Drop support for Ruby 2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,6 @@ aliases:
           bundle exec rspec
 
 jobs:
-  build-2.4:
-    docker:
-      - image: ruby:2.4
-    steps:
-      *build-steps
-
   build-2.5:
     docker:
       - image: ruby:2.5
@@ -49,7 +43,6 @@ workflows:
 
   build:
     jobs:
-      - build-2.4
       - build-2.5
       - build-2.6
       - build-2.7

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ nix-env --install --file https://github.com/ryota-ka/twterm/archive/master.tar
 
 ####  Requirements
 
-- Ruby (>= 2.4, compiled with ncurses and Readline)
+- Ruby (>= 2.5, compiled with ncurses and Readline)
 - ncurses
 - Readline
 - [GNU Libidn](https://www.gnu.org/software/libidn/)

--- a/twterm.gemspec
+++ b/twterm.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |i| i == 'Gemfile.lock' }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = spec.required_ruby_version = Gem::Requirement.new('>= 2.5')
 
   spec.add_dependency 'curses', '~> 1.3.2'
   spec.add_dependency 'concurrent-ruby', '~> 1.0.5'


### PR DESCRIPTION
As [Ruby 2.4 has reached its EOL this March](https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/), we'll drop the support for it.