### PR TITLE
Publish AbstractStatusTab#search_query_window

### DIFF
--- a/lib/twterm/tab/statuses/abstract_statuses_tab.rb
+++ b/lib/twterm/tab/statuses/abstract_statuses_tab.rb
@@ -177,6 +177,11 @@ module Twterm
             .then { render }
         end
 
+        # for the sake of Twterm::Tab::Searchable
+        def search_query_window
+          app.search_query_window
+        end
+
         def show_conversation
           status = highlighted_original_status
 
@@ -261,11 +266,6 @@ module Twterm
             statuses.each { |s| append(s) }
             sort
           end
-        end
-
-        # for the sake of Twterm::Tab::Searchable
-        def search_query_window
-          app.search_query_window
         end
 
         def sort


### PR DESCRIPTION
Delegations to private methods cause warnings.
https://bugs.ruby-lang.org/issues/12782
